### PR TITLE
fix foreign key constraint

### DIFF
--- a/src/migrations/2014_06_05_120003_create_thor_pages_table.php
+++ b/src/migrations/2014_06_05_120003_create_thor_pages_table.php
@@ -34,7 +34,7 @@ class CreateThorPagesTable extends Migration
             $table->integer('page_id')->unsigned();
             $table->integer('language_id')->unsigned();
             $table->foreign('page_id')->references('id')->on('pages')->onDelete('cascade');
-            $table->foreign('language_id')->references('language_id')->on('languages')->onDelete('cascade');
+            $table->foreign('language_id')->references('id')->on('languages')->onDelete('cascade');
             $table->string('title')->nullable()->default(null);
             $table->text('content')->nullable()->default(null);
             $table->text('slug')->nullable()->default(null);


### PR DESCRIPTION
This one took me an hour to figure out. 

If you run ```php artisian thor:install``` you'll come across an error message when running the migrations. The issue relates to the column name on the foreign key constraint for language id.